### PR TITLE
Clarify license in file preambles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog for tasty-quickcheck-laws
 ===================================
 
+Unreleased changes
+------------------
+
+* Fixed
+    * Clarified license (it's BSD3)
+
 0.0.1
 -----
 

--- a/src/Test/Tasty/QuickCheck/Laws.hs
+++ b/src/Test/Tasty/QuickCheck/Laws.hs
@@ -2,7 +2,7 @@
 Module      : Test.Tasty.QuickCheck.Laws
 Description : Prefab tasty trees of quickcheck properties for lawful type classes
 Copyright   : 2018, Automattic, Inc.
-License     : GPL-3
+License     : BSD3
 Maintainer  : Nathan Bloomfield (nbloomf@gmail.com)
 Stability   : experimental
 Portability : POSIX

--- a/src/Test/Tasty/QuickCheck/Laws/Applicative.hs
+++ b/src/Test/Tasty/QuickCheck/Laws/Applicative.hs
@@ -2,7 +2,7 @@
 Module      : Test.Tasty.QuickCheck.Laws.Applicative
 Description : Prefab tasty trees of quickcheck properties for the Applicative laws
 Copyright   : 2018, Automattic, Inc.
-License     : GPL-3
+License     : BSD3
 Maintainer  : Nathan Bloomfield (nbloomf@gmail.com)
 Stability   : experimental
 Portability : POSIX

--- a/src/Test/Tasty/QuickCheck/Laws/Class.hs
+++ b/src/Test/Tasty/QuickCheck/Laws/Class.hs
@@ -2,7 +2,7 @@
 Module      : Test.Tasty.QuickCheck.Laws.Class
 Description : Convenience typeclass
 Copyright   : 2018, Automattic, Inc.
-License     : GPL-3
+License     : BSD3
 Maintainer  : Nathan Bloomfield (nbloomf@gmail.com)
 Stability   : experimental
 Portability : POSIX

--- a/src/Test/Tasty/QuickCheck/Laws/Eq.hs
+++ b/src/Test/Tasty/QuickCheck/Laws/Eq.hs
@@ -2,7 +2,7 @@
 Module      : Test.Tasty.QuickCheck.Laws.Eq
 Description : Prefab tasty trees of quickcheck properties for the Eq laws
 Copyright   : 2018, Automattic, Inc.
-License     : GPL-3
+License     : BSD3
 Maintainer  : Nathan Bloomfield (nbloomf@gmail.com)
 Stability   : experimental
 Portability : POSIX

--- a/src/Test/Tasty/QuickCheck/Laws/ErrorMonad.hs
+++ b/src/Test/Tasty/QuickCheck/Laws/ErrorMonad.hs
@@ -2,7 +2,7 @@
 Module      : Test.Tasty.QuickCheck.Laws.ErrorMonad
 Description : Prefab tasty trees of quickcheck properties for error monad laws
 Copyright   : 2018, Automattic, Inc.
-License     : GPL-3
+License     : BSD3
 Maintainer  : Nathan Bloomfield (nbloomf@gmail.com)
 Stability   : experimental
 Portability : POSIX

--- a/src/Test/Tasty/QuickCheck/Laws/Functor.hs
+++ b/src/Test/Tasty/QuickCheck/Laws/Functor.hs
@@ -2,7 +2,7 @@
 Module      : Test.Tasty.QuickCheck.Laws.Functor
 Description : Prefab tasty trees of quickcheck properties for the Functor laws
 Copyright   : 2018, Automattic, Inc.
-License     : GPL-3
+License     : BSD3
 Maintainer  : Nathan Bloomfield (nbloomf@gmail.com)
 Stability   : experimental
 Portability : POSIX

--- a/src/Test/Tasty/QuickCheck/Laws/Monad.hs
+++ b/src/Test/Tasty/QuickCheck/Laws/Monad.hs
@@ -2,7 +2,7 @@
 Module      : Test.Tasty.QuickCheck.Laws.Monad
 Description : Prefab tasty trees of quickcheck properties for the Monad laws
 Copyright   : 2018, Automattic, Inc.
-License     : GPL-3
+License     : BSD3
 Maintainer  : Nathan Bloomfield (nbloomf@gmail.com)
 Stability   : experimental
 Portability : POSIX

--- a/src/Test/Tasty/QuickCheck/Laws/Monoid.hs
+++ b/src/Test/Tasty/QuickCheck/Laws/Monoid.hs
@@ -2,7 +2,7 @@
 Module      : Test.Tasty.QuickCheck.Laws.Monoid
 Description : Prefab tasty trees of quickcheck properties for the Monoid laws
 Copyright   : 2018, Automattic, Inc.
-License     : GPL-3
+License     : BSD3
 Maintainer  : Nathan Bloomfield (nbloomf@gmail.com)
 Stability   : experimental
 Portability : POSIX

--- a/src/Test/Tasty/QuickCheck/Laws/ReaderMonad.hs
+++ b/src/Test/Tasty/QuickCheck/Laws/ReaderMonad.hs
@@ -2,7 +2,7 @@
 Module      : Test.Tasty.QuickCheck.Laws.ReaderMonad
 Description : Prefab tasty trees of quickcheck properties for the reader monad laws
 Copyright   : 2018, Automattic, Inc.
-License     : GPL-3
+License     : BSD3
 Maintainer  : Nathan Bloomfield (nbloomf@gmail.com)
 Stability   : experimental
 Portability : POSIX

--- a/src/Test/Tasty/QuickCheck/Laws/StateMonad.hs
+++ b/src/Test/Tasty/QuickCheck/Laws/StateMonad.hs
@@ -2,7 +2,7 @@
 Module      : Test.Tasty.QuickCheck.Laws.StateMonad
 Description : Prefab tasty trees of quickcheck properties for the state monad laws
 Copyright   : 2018, Automattic, Inc.
-License     : GPL-3
+License     : BSD3
 Maintainer  : Nathan Bloomfield (nbloomf@gmail.com)
 Stability   : experimental
 Portability : POSIX

--- a/src/Test/Tasty/QuickCheck/Laws/WriterMonad.hs
+++ b/src/Test/Tasty/QuickCheck/Laws/WriterMonad.hs
@@ -2,7 +2,7 @@
 Module      : Test.Tasty.QuickCheck.Laws.WriterMonad
 Description : Prefab tasty trees of quickcheck properties for writer monad laws
 Copyright   : 2018, Automattic, Inc.
-License     : GPL-3
+License     : BSD3
 Maintainer  : Nathan Bloomfield (nbloomf@gmail.com)
 Stability   : experimental
 Portability : POSIX


### PR DESCRIPTION
Fixes a copy-paste error that made the code license unclear.

Addresses #1.